### PR TITLE
Add an ignore_ground option.

### DIFF
--- a/include/annotate/annotate_node.h
+++ b/include/annotate/annotate_node.h
@@ -40,6 +40,7 @@ public:
   int id() const;
   Track const& track() const;
   void setTrack(const Track& track);
+  void setIgnoreGround(bool enabled);
 
   void setTime(const ros::Time& time);
 
@@ -133,6 +134,7 @@ private:
   tf::TransformBroadcaster tf_broadcaster_;
   State state_{ New };
   std::stack<UndoState> undo_stack_;
+  bool ignore_ground_{ false };
 };
 
 class Markers
@@ -162,5 +164,6 @@ private:
   ros::Time last_track_publish_time_;
   sensor_msgs::PointCloud2ConstPtr cloud_;
   tf::TransformListener transform_listener_;
+  bool ignore_ground_{ false };
 };
 }  // namespace annotate

--- a/launch/annotate.launch
+++ b/launch/annotate.launch
@@ -3,9 +3,11 @@
 	<arg name="labels" default="person,car,truck,bus,train,motorcycle,bicycle" />
 	<arg name="annotations" default="annotate.yaml" />
 	<arg name="pointcloud_topic" default="/velodyne_points" />
+	<arg name="ignore_ground" default="false" />
 	<node name="annotate" pkg="annotate" type="annotate_node" output="screen">
 		<param name="labels" value="$(arg labels)" />
 		<param name="annotations" value="$(arg annotations)" />
 		<param name="pointcloud_topic" value="$(arg pointcloud_topic)" />
+		<param name="ignore_ground" value="$(arg ignore_ground)" />
 	</node>
 </launch>

--- a/launch/demo.launch
+++ b/launch/demo.launch
@@ -4,10 +4,12 @@
 	<arg name="labels" default="person,car,motorcycle,bicycle" />
 	<arg name="annotations" default="annotate.yaml" />
 	<arg name="pointcloud_topic" default="/velodyne_points" />
+	<arg name="ignore_ground" default="false" />
 	<include file="$(find annotate)/launch/annotate.launch">
 		<arg name="labels" value="$(arg labels)" />
 		<arg name="annotations" value="$(arg annotations)" />
 		<arg name="pointcloud_topic" value="$(arg pointcloud_topic)" />
+		<arg name="ignore_ground" value="$(arg ignore_ground)" />
 	</include>
 	<node type="rviz" name="rviz" pkg="rviz" args="-d $(find annotate)/launch/demo.rviz" />
 	<node pkg="rosbag" type="play" name="playback" output="screen" args="--clock $(arg bag)" if="$(eval bag != '')" launch-prefix="xterm -e" />


### PR DESCRIPTION
When enabled, prevents automated box-growing features like
box expansion and auto-fit to increase towards the negative
z axis. This is useful when the point cloud contains
ground points which should not be included in object
annotations typically.

closes #7