### PR TITLE
Add support for shortcuts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,9 +60,11 @@ src/${PROJECT_NAME}_display.cpp
 src/${PROJECT_NAME}_tool.cpp
 src/annotation_marker.cpp
 src/file_dialog_property.cpp
+src/shortcut_property.cpp
 include/${PROJECT_NAME}/${PROJECT_NAME}_display.h
 include/${PROJECT_NAME}/${PROJECT_NAME}_tool.h
 include/${PROJECT_NAME}/file_dialog_property.h
+include/${PROJECT_NAME}/shortcut_property.h
 )
 target_link_libraries(${PROJECT_NAME} ${QT_LIBRARIES} ${catkin_LIBRARIES} yaml-cpp)
 

--- a/icons/classes/Keyboard.svg
+++ b/icons/classes/Keyboard.svg
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xml:space="preserve"
+   version="1.1"
+   style="image-rendering:optimizeQuality;shape-rendering:geometricPrecision;text-rendering:geometricPrecision"
+   viewBox="0 0 100 57.162472"
+   x="0px"
+   y="0px"
+   fill-rule="evenodd"
+   clip-rule="evenodd"
+   id="svg14"
+   sodipodi:docname="Keyboard.svg"
+   width="100"
+   height="57.162472"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"><metadata
+     id="metadata18"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><sodipodi:namedview
+     fit-margin-bottom="0"
+     fit-margin-right="0"
+     fit-margin-left="0"
+     fit-margin-top="0"
+     inkscape:document-rotation="0"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1103"
+     id="namedview16"
+     showgrid="false"
+     inkscape:zoom="5.6568543"
+     inkscape:cx="31.312077"
+     inkscape:cy="-6.662432"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg14" /><defs
+     id="defs4"><style
+       type="text/css"
+       id="style2">
+   
+    .fil0 {fill:black;fill-rule:nonzero}
+   
+  </style></defs><g
+     id="g8"
+     transform="scale(45.76659)"
+     style="stroke-width:0.02185"><path
+       class="fil0"
+       d="m 0.052,0 h 2.081 c 0.029,0 0.052,0.023 0.052,0.052 v 1.145 c 0,0.029 -0.023,0.052 -0.052,0.052 H 0.052 C 0.023,1.249 0,1.226 0,1.197 V 0.052 C 0,0.023 0.023,0 0.052,0 Z M 0.476,0.833 V 0.989 H 0.241 V 0.833 Z m 1.449,0 V 0.989 H 1.691 V 0.833 Z m -0.383,0 v 0.156 c -0.306,0 -0.611,0 -0.917,0 V 0.833 c 0.306,0 0.611,0 0.917,0 z M 1.464,0.546 H 1.62 V 0.702 H 1.464 Z m 0.305,0 H 1.925 V 0.702 H 1.769 Z m -0.611,0 H 1.314 V 0.702 H 1.158 Z m -0.305,0 H 1.009 V 0.702 H 0.853 Z m -0.306,0 H 0.703 V 0.702 H 0.547 Z M 1.769,0.26 H 1.925 V 0.416 H 1.769 Z m -0.305,0 H 1.62 V 0.416 H 1.464 Z m -0.306,0 H 1.314 V 0.416 H 1.158 Z m -0.305,0 H 1.009 V 0.416 H 0.853 Z m -0.306,0 H 0.703 V 0.416 H 0.547 Z M 0.241,0.546 H 0.398 V 0.702 H 0.241 Z m 0,-0.286 H 0.398 V 0.416 H 0.241 Z M 2.081,0.104 H 0.104 v 1.041 h 1.977 z"
+       id="path6"
+       style="stroke-width:0.02185" /></g></svg>

--- a/icons/classes/README.md
+++ b/icons/classes/README.md
@@ -1,0 +1,3 @@
+## Icon Origins
+* [```New Annotation.svg```](New%20Annotation.svg) by Dennis Nienhüser
+* [```Keyboard.svg```](Keyboard.svg) by Deemak Daksina from [the Noun Project](https://thenounproject.com/browse/?i=1630214).

--- a/include/annotate/annotate_display.h
+++ b/include/annotate/annotate_display.h
@@ -2,6 +2,7 @@
 
 #include "annotation_marker.h"
 #include "file_dialog_property.h"
+#include "shortcut_property.h"
 #include <ros/ros.h>
 #include <interactive_markers/interactive_marker_server.h>
 #include <interactive_markers/menu_handler.h>
@@ -35,6 +36,7 @@ public:
   void onInitialize() override;
   void setTopic(const QString& topic, const QString& datatype) override;
   void load(const rviz::Config& config) override;
+  void setCurrentMarker(AnnotationMarker* marker);
 
   bool save();
   void publishTrackMarkers();
@@ -47,12 +49,19 @@ private Q_SLOTS:
   void openFile();
   void updateAnnotationFile();
   void updateIgnoreGround();
+  void autoFitPoints();
+  void undo();
+  void commit();
+  void rotateClockwise();
+  void rotateAntiClockwise();
+  void togglePlayPause();
+  void updateShortcuts();
 
 private:
   template <class T>
   void modifyChild(rviz::Property* parent, QString const& name, std::function<void(T*)> modifier);
   void adjustView();
-  bool load(std::string const &file);
+  bool load(std::string const& file);
   void createNewAnnotation(const geometry_msgs::PointStamped::ConstPtr& message);
   void handlePointcloud(const sensor_msgs::PointCloud2ConstPtr& cloud);
 
@@ -78,5 +87,8 @@ private:
   rviz::Display* cloud_display_{ nullptr };
   rviz::Display* marker_display_{ nullptr };
   rviz::Display* track_display_{ nullptr };
+  AnnotationMarker* current_marker_{ nullptr };
+  BoolProperty* shortcuts_property_{ nullptr };
+  ros::ServiceClient playback_client_;
 };
 }  // namespace annotate

--- a/include/annotate/annotation_marker.h
+++ b/include/annotate/annotation_marker.h
@@ -48,6 +48,10 @@ public:
   void setLabels(const std::vector<std::string>& labels);
 
   void setTime(const ros::Time& time);
+  void autoFit();
+  void undo();
+  void commit();
+  void rotateYaw(double delta_rad);
 
 private:
   using MenuHandler = interactive_markers::MenuHandler;
@@ -138,13 +142,12 @@ private:
   bool hasMoved(geometry_msgs::Pose const& a, geometry_msgs::Pose const& b) const;
   void saveMove();
   void saveForUndo(const std::string& description);
-  void undo();
   void undo(const visualization_msgs::InteractiveMarkerFeedbackConstPtr& feedback);
   void resize(double offset);
   PointContext analyzePoints() const;
   void shrinkTo(const PointContext& context);
   void shrink(const visualization_msgs::InteractiveMarkerFeedbackConstPtr& feedback);
-  bool autoFit();
+  bool fitNearbyPoints();
   void autoFit(const visualization_msgs::InteractiveMarkerFeedbackConstPtr& feedback);
   void pull();
   void push();

--- a/include/annotate/shortcut_property.h
+++ b/include/annotate/shortcut_property.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <rviz/properties/string_property.h>
+#include <QShortcut>
+#include <rviz/display.h>
+
+class ShortcutProperty : public rviz::StringProperty
+{
+  Q_OBJECT
+public:
+  ShortcutProperty(const QString& name = QString(), const QString& default_value = QString(),
+                   const QString& description = QString(), rviz::Property* parent = 0, const char* changed_slot = 0,
+                   QObject* receiver = 0);
+
+  /**
+   * Install a shortcut in target that calls trigger_slot in receiver. The shortcut is derived from getName(),
+   * which should be a shortcut string that Qt understands (cf QKeySequence). If a shortcut is invalid or used
+   * already, a warning status is set in display.
+   */
+  void createShortcut(rviz::Display* display, QWidget* target, QObject* receiver, const char* trigger_slot);
+  void setEnabled(bool enabled);
+
+private Q_SLOTS:
+  void updateShortcut();
+  void handleAmbiguousShortcut();
+
+private:
+  QString statusName() const;
+  QShortcut* shortcut_{ nullptr };
+  rviz::Display* display_{ nullptr };
+};

--- a/launch/demo.launch
+++ b/launch/demo.launch
@@ -2,5 +2,5 @@
 <launch>
 	<arg name="bag" default="" />
 	<node type="rviz" name="rviz" pkg="rviz" args="-d $(find annotate)/launch/demo.rviz" />
-	<node pkg="rosbag" type="play" name="playback" output="screen" args="--clock $(arg bag)" if="$(eval bag != '')" launch-prefix="xterm -e" />
+	<node pkg="rosbag" type="play" name="playback" output="screen" args="--clock --quiet $(arg bag)" if="$(eval bag != '')" />
 </launch>

--- a/launch/demo.rviz
+++ b/launch/demo.rviz
@@ -4,8 +4,10 @@ Panels:
     Name: Displays
     Property Tree Widget:
       Expanded:
+        - /Global Options1
         - /Annotated PointCloud21
         - /Annotated PointCloud21/Status1
+        - /Annotated PointCloud21/Shortcuts1
       Splitter Ratio: 0.5299999713897705
     Tree Height: 517
   - Class: rviz/Selection
@@ -57,8 +59,8 @@ Visualization Manager:
         - Alpha: 1
           Autocompute Intensity Bounds: true
           Autocompute Value Bounds:
-            Max Value: 4.55654764175415
-            Min Value: -0.9923917651176453
+            Max Value: 8.158509254455566
+            Min Value: 0.03612864017486572
             Value: true
           Axis: Z
           Channel Name: intensity
@@ -103,18 +105,26 @@ Visualization Manager:
           Queue Size: 100
           Value: true
       Enabled: true
-      File: /workspace/annotate4.yaml
+      File: /workspace/LCAS/LCAS_20160523_1227_1238.yaml
       Ignore Ground: false
-      Labels: bicycle, car, pedestrian
+      Labels: person
       Name: Annotated PointCloud2
       Open: ""
+      Shortcuts:
+        Value: true
+        auto fit points: Ctrl+F
+        commit annotation: Ctrl+C
+        rotate anti-clockwise: left
+        rotate clockwise: right
+        toggle pause: space
+        undo: Ctrl+Z
       Topic: /velodyne_object_points
       Value: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
     Default Light: true
-    Fixed Frame: world
+    Fixed Frame: base_link
     Frame Rate: 30
   Name: root
   Tools:
@@ -139,25 +149,25 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz/Orbit
-      Distance: 23.477920532226562
+      Distance: 9.748343467712402
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
       Focal Point:
-        X: 15.84809398651123
-        Y: 5.369266033172607
-        Z: -1.1118619441986084
+        X: 3.0042378902435303
+        Y: -1.845599889755249
+        Z: -2.215280055999756
       Focal Shape Fixed Size: true
       Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.9647979736328125
+      Pitch: 1.119796872138977
       Target Frame: <Fixed Frame>
       Value: Orbit (rviz)
-      Yaw: 1.6385496854782104
+      Yaw: 3.0690348148345947
     Saved:
       - Angle: 2.2950024604797363
         Class: rviz/TopDownOrtho
@@ -210,5 +220,5 @@ Window Geometry:
   Views:
     collapsed: false
   Width: 1394
-  X: 317
-  Y: 194
+  X: 215
+  Y: 135

--- a/src/shortcut_property.cpp
+++ b/src/shortcut_property.cpp
@@ -1,0 +1,70 @@
+#include <rviz/properties/property.h>
+#include <annotate/shortcut_property.h>
+#include <QFileDialog>
+#include <QPushButton>
+
+ShortcutProperty::ShortcutProperty(const QString& name, const QString& default_value, const QString& description,
+                                   rviz::Property* parent, const char* changed_slot, QObject* receiver)
+  : rviz::StringProperty(name, default_value, description, parent, changed_slot, receiver)
+{
+  connect(this, SIGNAL(changed()), this, SLOT(updateShortcut()));
+}
+
+void ShortcutProperty::createShortcut(rviz::Display* display, QWidget* target, QObject* receiver,
+                                      const char* trigger_slot)
+{
+  display_ = display;
+  shortcut_ = new QShortcut(target);
+  connect(shortcut_, SIGNAL(activated()), receiver, trigger_slot);
+  connect(shortcut_, SIGNAL(activatedAmbiguously()), this, SLOT(handleAmbiguousShortcut()));
+  updateShortcut();
+}
+
+QString ShortcutProperty::statusName() const
+{
+  return QString("Shortcut %1").arg(getName());
+}
+
+void ShortcutProperty::setEnabled(bool enabled)
+{
+  if (shortcut_)
+  {
+    shortcut_->setEnabled(enabled);
+  }
+}
+
+void ShortcutProperty::updateShortcut()
+{
+  if (shortcut_)
+  {
+    auto const key_sequence = QKeySequence(getString());
+    if (key_sequence.isEmpty())
+    {
+      if (display_)
+      {
+        display_->setStatus(rviz::StatusProperty::Warn, statusName(),
+                            QString("The keyboard shortcut '%1' is invalid. Please choose a valid shortcut like "
+                                    "'Ctrl+D'.")
+                                .arg(getString()));
+      }
+    }
+    else
+    {
+      shortcut_->setKey(key_sequence);
+      if (display_)
+      {
+        display_->deleteStatus(statusName());
+      }
+    }
+  }
+}
+
+void ShortcutProperty::handleAmbiguousShortcut()
+{
+  if (display_)
+  {
+    display_->setStatus(
+        rviz::StatusProperty::Warn, statusName(),
+        QString("The keyboard shortcut '%1' is already used. Please choose a different one.").arg(getString()));
+  }
+}


### PR DESCRIPTION
Shortcuts are provided with the help of QShortcut instances attached to
the render panel. A custom rviz property allows configuration of the
shortcut key.

Keyboard icon by Deemak Daksina from the Noun Project.

closes #16