### PR TITLE
Bugfix: Using Time(double) to take double point timestamp

### DIFF
--- a/src/annotation_marker.cpp
+++ b/src/annotation_marker.cpp
@@ -747,8 +747,7 @@ AnnotationMarker::PointContext AnnotationMarker::analyzePoints() const
             context.maximum.setMax(point);
             if (has_timestamp)
             {
-              ros::Time point_time;
-              point_time.fromNSec(**iter_timestamp);
+              ros::Time point_time(**iter_timestamp);
               time_offsets += point_time - context.time;
             }
           }


### PR DESCRIPTION
The **iter_timestamp is in seconds (of type double) but ros::Time::fromNSec(uint64_t) expects nanoseconds (of type uint64_t) which caused segfault in analyzePoints. Bug fixed by using ros::Time(double) to get point_time.